### PR TITLE
Execute .init_array, passing arg_count, arg_pointer, and env_pointer contrary to POSIX

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,3 @@
 pub fn round_up_to_boundary(address: usize, boundary: usize) -> usize {
-    boundary * (address / boundary)
+    boundary * address.div_ceil(boundary)
 }


### PR DESCRIPTION
It looks as though I forgot to call the init array in static pie, and it looks as though there are some other important details:
<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/6eb4f94e-1d8c-4311-b3c1-a8a376a2bafc" />
These people really can't follow a standard... I do think this is a good idea though so I'll do the same.

One thing this commit fixs is now we can actually use rusts built in args...
But it means that if our target_env ever changes from gnu we're going to have other issues.

Closes #7 