### PR TITLE
merge(raw_pointer_migration): replace &'static slices with *const [T] fat pointers;

### DIFF
--- a/src/elf/string_table.rs
+++ b/src/elf/string_table.rs
@@ -34,7 +34,7 @@ impl StringTable {
     }
 
     /// Retrieves a string from the table at the specified byte offset.
-    pub unsafe fn get(&self, index: usize) -> &'static str {
+    pub unsafe fn get(&self, index: usize) -> &str {
         let string_start = self.0.add(index);
         let length = (0..).find(|&index| *string_start.add(index) == 0).unwrap();
         str::from_utf8_unchecked(slice::from_raw_parts(string_start, length))

--- a/src/objects/object_data/mod.rs
+++ b/src/objects/object_data/mod.rs
@@ -6,8 +6,7 @@ pub use dynamic_trait_objects::{AnyDynamic, Dynamic, DynamicObject, NonDynamic};
 pub use hash_tables::HashTable;
 pub use thread_local::{ThreadLocalAllocation, ThreadLocalData};
 
-use std::slice;
-use std::{ffi::c_void, ptr::null};
+use std::{ffi::c_void, ptr, ptr::null};
 
 use crate::elf::dynamic_array::{DT_GNU_HASH, DT_HASH, DT_NEEDED, DT_PLTGOT};
 use crate::elf::header::ElfHeader;
@@ -41,9 +40,9 @@ pub struct ObjectData<T: AnyDynamic> {
     pub global_offset_table: *const usize,
     pub string_table: StringTable,
     pub symbol_table: SymbolTable,
-    pub rela_slice: &'static [Rela],
+    rela_slice: *const [Rela],
     pub tls_data: Option<ThreadLocalData>,
-    pub init_array: Option<&'static [InitArrayFunction]>,
+    init_array: Option<*const [InitArrayFunction]>,
     pub hash_table: Option<HashTable>,
 
     pub needed_libraries: T,
@@ -58,20 +57,28 @@ impl ObjectData<Dynamic> {
 }
 
 impl<T: AnyDynamic> ObjectData<T> {
+    pub unsafe fn rela_slice(&self) -> &[Rela] {
+        &*self.rela_slice
+    }
+
+    pub unsafe fn init_functions(&self) -> Option<&[InitArrayFunction]> {
+        self.init_array.map(|pointer| &*pointer)
+    }
+
     pub unsafe fn from_base(base: *const c_void) -> Self {
         // ELf Header:
         let header = &*(base as *const ElfHeader);
         syscall_debug_assert!(header.e_phentsize == size_of::<ProgramHeader>() as u16);
 
         // Program Headers:
-        let program_header_table = slice::from_raw_parts(
+        let program_header_table = ptr::slice_from_raw_parts(
             base.byte_add(header.e_phoff) as *const ProgramHeader,
             header.e_phnum as usize,
         );
 
         let mut dynamic_program_header = null();
         let mut tls_program_header = None;
-        for header in program_header_table {
+        for header in &*program_header_table {
             match header.p_type {
                 PT_DYNAMIC => dynamic_program_header = header,
                 PT_TLS => tls_program_header = Some(header.to_owned()),
@@ -83,14 +90,15 @@ impl<T: AnyDynamic> ObjectData<T> {
     }
 
     pub unsafe fn from_program_headers(
-        program_header_table: &'static [ProgramHeader],
+        program_header_table: *const [ProgramHeader],
     ) -> ObjectData<T> {
         let (mut base, mut dynamic_program_header) = (null(), null());
         let mut tls_program_header = None;
-        for header in program_header_table {
+        for header in &*program_header_table {
             match header.p_type {
                 PT_PHDR => {
-                    base = program_header_table.as_ptr().byte_sub(header.p_vaddr) as *const c_void;
+                    base = (*program_header_table).as_ptr().byte_sub(header.p_vaddr)
+                        as *const c_void;
                 }
                 PT_DYNAMIC => dynamic_program_header = header,
                 PT_TLS => tls_program_header = Some(header.to_owned()),
@@ -175,12 +183,12 @@ impl<T: AnyDynamic> ObjectData<T> {
         let symbol_table = SymbolTable::new(symbol_table_pointer);
 
         syscall_debug_assert!(rela_pointer != null());
-        let rela_slice = slice::from_raw_parts(rela_pointer, rela_count);
+        let rela_slice = ptr::slice_from_raw_parts(rela_pointer, rela_count);
 
         let init_array = if init_array_pointer.is_null() || init_array_size == 0 {
             None
         } else {
-            Some(slice::from_raw_parts(init_array_pointer, init_array_size))
+            Some(ptr::slice_from_raw_parts(init_array_pointer, init_array_size))
         };
 
         Self {

--- a/src/objects/strategies/init_array.rs
+++ b/src/objects/strategies/init_array.rs
@@ -32,8 +32,7 @@ impl InitArray {
 impl<T: AsObjectDataSlice> Stratagem<T> for InitArray {
     fn run(&self, object_data: &mut T) -> Result<(), MirosError> {
         object_data.as_object_slice_mut().iter().for_each(|object| {
-            if let Some(init_functions) = object.init_array {
-                // Call each initialization function in order
+            if let Some(init_functions) = unsafe { object.init_functions() } {
                 init_functions
                     .iter()
                     .filter(|init_fn| **init_fn as *const c_void != null())

--- a/src/objects/strategies/relocate.rs
+++ b/src/objects/strategies/relocate.rs
@@ -88,8 +88,7 @@ where
             .as_object_slice_mut()
             .iter()
             .try_for_each(|object| {
-                object
-                    .rela_slice
+                unsafe { object.rela_slice() }
                     .iter()
                     .try_for_each(|rela| unsafe { self.rela(*rela, object) })
             })

--- a/src/objects/strategies/thread_local_storage.rs
+++ b/src/objects/strategies/thread_local_storage.rs
@@ -13,11 +13,11 @@ use crate::{
 };
 
 pub struct ThreadLocalStorage {
-    pseudorandom_bytes: &'static [u8; 16],
+    pseudorandom_bytes: *const [u8; 16],
 }
 
 impl ThreadLocalStorage {
-    pub fn new(pseudorandom_bytes: &'static [u8; 16]) -> Self {
+    pub fn new(pseudorandom_bytes: *const [u8; 16]) -> Self {
         Self { pseudorandom_bytes }
     }
 }
@@ -101,7 +101,7 @@ impl Stratagem<ObjectDataSingle> for ThreadLocalStorage {
                 dynamic_thread_vector: null_mut(),
                 _padding: [0; 3],
                 canary: usize::from_ne_bytes(
-                    (*self.pseudorandom_bytes)[..size_of::<usize>()]
+                    (&*self.pseudorandom_bytes)[..size_of::<usize>()]
                         .try_into()
                         .unwrap(),
                 ),

--- a/src/start/mod.rs
+++ b/src/start/mod.rs
@@ -15,8 +15,7 @@ use crate::{
 use std::{
     arch::naked_asm,
     env,
-    ptr::{null, null_mut},
-    slice,
+    ptr::{self, null, null_mut},
 };
 
 pub mod auxiliary_vector;
@@ -81,21 +80,21 @@ pub unsafe extern "C" fn relocate_and_calculate_jump_address(stack_pointer: *mut
     syscall_debug_assert!(auxv_info.base.addr() & (auxv_info.page_size - 1) == 0);
     page_size::set_page_size(auxv_info.page_size);
 
-    let program_header_table = slice::from_raw_parts(
+    let program_header_table = ptr::slice_from_raw_parts(
         auxv_info.program_header_pointer,
         auxv_info.program_header_count,
     );
 
     // Relocate ourselves and initialize thread local storage:
     let mut miros = if auxv_info.base.is_null() {
-        ObjectData::<NonDynamic>::from_program_headers(&program_header_table)
+        ObjectData::<NonDynamic>::from_program_headers(program_header_table)
     } else {
         ObjectData::from_base(auxv_info.base)
     };
 
     let relocate = Relocate::new();
     let thread_local_storage =
-        ThreadLocalStorage::new(auxv_info.pseudorandom_bytes.as_ref().unwrap_unchecked());
+        ThreadLocalStorage::new(auxv_info.pseudorandom_bytes);
     let init_array = InitArray::new(arg_count, arg_pointer, env_pointer, auxv_pointer);
 
     let stratagems: &[&dyn Stratagem<ObjectDataSingle>] = &[&thread_local_storage, &init_array];
@@ -114,7 +113,7 @@ pub unsafe extern "C" fn relocate_and_calculate_jump_address(stack_pointer: *mut
     let executable = if auxv_info.base.is_null() {
         todo!()
     } else {
-        ObjectData::<Dynamic>::from_program_headers(&program_header_table)
+        ObjectData::<Dynamic>::from_program_headers(program_header_table)
     };
     let mut executable_and_dependencies = Vec::from([executable]);
 


### PR DESCRIPTION
- Replace `rela_slice` & `init_array` fields with `*const [T]` raw fat pointers, add safe accessor methods
- Change `from_program_headers` parameter from `&'static [ProgramHeader]` to `*const [ProgramHeader]`
- Change `ThreadLocalStorage.pseudorandom_bytes` from `&'static [u8; 16]` to `*const [u8; 16]`
- Change `StringTable::get` return type from `&'static str` to `&str`

Closes: #33