### PR TITLE
merge(syscall-number-enum): centralize syscall numbers into shared enum;

### DIFF
--- a/src/libc/fs/close.rs
+++ b/src/libc/fs/close.rs
@@ -3,6 +3,7 @@ use std::{arch::asm, os::fd::RawFd};
 use crate::{
     libc::errno::{set_errno, Errno},
     signature_matches_libc,
+    syscall::Syscall,
 };
 
 #[no_mangle]
@@ -17,10 +18,9 @@ unsafe extern "C" fn close(file_descriptor: RawFd) -> i32 {
     let result: isize;
     #[cfg(target_arch = "x86_64")]
     {
-        const CLOSE: usize = 3;
         asm!(
             "syscall",
-            inlateout("rax") CLOSE => result,
+            inlateout("rax") Syscall::Close as usize => result,
             in("rdi") file_descriptor,
             lateout("rcx") _,
             lateout("r11") _,

--- a/src/libc/fs/open.rs
+++ b/src/libc/fs/open.rs
@@ -1,5 +1,6 @@
 use crate::libc::errno::{set_errno, Errno};
 use crate::signature_matches_libc;
+use crate::syscall::Syscall;
 use std::ffi::VaList;
 
 use std::arch::asm;
@@ -27,10 +28,9 @@ unsafe extern "C" fn open64(pathname: *const i8, flags: OFlags, mut args: VaList
 
     #[cfg(target_arch = "x86_64")]
     {
-        const OPENAT: usize = 257;
         asm!(
             "syscall",
-            inlateout("rax") OPENAT => result,
+            inlateout("rax") Syscall::OpenAt as usize => result,
             in("rdi") 0, // directory_file_descriptor
             in("rsi") pathname,
             in("rdx") flags.raw_value(),

--- a/src/libc/fs/read.rs
+++ b/src/libc/fs/read.rs
@@ -2,7 +2,7 @@ use std::ffi::c_void;
 use std::os::fd::AsRawFd;
 use std::{arch::asm, os::fd::BorrowedFd};
 
-use crate::signature_matches_libc;
+use crate::{signature_matches_libc, syscall::Syscall};
 
 #[no_mangle]
 unsafe extern "C" fn read(
@@ -18,13 +18,11 @@ unsafe extern "C" fn read(
 
     #[cfg(target_arch = "x86_64")]
     {
-        const READ: usize = 0;
-
         let result: isize;
         unsafe {
             asm!(
                 "syscall",
-                inlateout("rax") READ => result,
+                inlateout("rax") Syscall::Read as usize => result,
                 in("rdi") file_descriptor.as_raw_fd(),
                 in("rsi") buffer_pointer,
                 in("rdx") buffer_length_in_bytes,

--- a/src/libc/fs/write.rs
+++ b/src/libc/fs/write.rs
@@ -1,6 +1,6 @@
 use std::{arch::asm, ffi::c_void};
 
-use crate::signature_matches_libc;
+use crate::{signature_matches_libc, syscall::Syscall};
 
 pub const STD_IN: i32 = 0;
 pub const STD_OUT: i32 = 1;
@@ -18,13 +18,11 @@ unsafe extern "C" fn write(
         buffer_length_in_bytes
     ));
 
-    const WRITE: usize = 1;
-
     let result: isize;
     unsafe {
         asm!(
             "syscall",
-            inlateout("rax") WRITE => result,
+            inlateout("rax") Syscall::Write as usize => result,
             in("rdi") file_descriptor,
             in("rsi") buffer_pointer,
             in("rdx") buffer_length_in_bytes,

--- a/src/libc/mem/mmap.rs
+++ b/src/libc/mem/mmap.rs
@@ -4,6 +4,7 @@ use crate::{
     io_macros::syscall_debug_assert,
     libc::mem::{MapFlags, ProtectionFlags},
     signature_matches_libc,
+    syscall::Syscall,
 };
 
 // TODO: add error handling
@@ -25,13 +26,11 @@ pub unsafe extern "C" fn mmap(
         file_offset as i64,
     ))
     .cast());
-    const MMAP: usize = 9; // I am like 80% sure this is the right system call... :)
-
     let mut result: isize;
     unsafe {
         asm!(
             "syscall",
-            inlateout("rax") MMAP => result,
+            inlateout("rax") Syscall::Mmap as usize => result,
             in("rdi") pointer,
             in("rsi") size,
             in("rdx") protection_flags.raw_value(),

--- a/src/libc/mem/mod.rs
+++ b/src/libc/mem/mod.rs
@@ -2,7 +2,7 @@
 use bitbybit::{bitenum, bitfield};
 use std::arch::asm;
 
-use crate::{io_macros::syscall_debug_assert, signature_matches_libc};
+use crate::{io_macros::syscall_debug_assert, signature_matches_libc, syscall::Syscall};
 
 mod mmap;
 pub use mmap::mmap;
@@ -46,13 +46,11 @@ pub struct MapFlags {
 pub unsafe fn munmap(pointer: *mut u8, size: usize) -> i32 {
     signature_matches_libc!(libc::munmap(pointer.cast(), size));
 
-    const MUNMAP: usize = 11;
-
     let mut result: isize;
     unsafe {
         asm!(
             "syscall",
-            inlateout("rax") MUNMAP => result,
+            inlateout("rax") Syscall::Munmap as usize => result,
             in("rdi") pointer,
             in("rsi") size,
             out("rcx") _,

--- a/src/libc/process/mod.rs
+++ b/src/libc/process/mod.rs
@@ -1,4 +1,4 @@
-use crate::signature_matches_libc;
+use crate::{signature_matches_libc, syscall::Syscall};
 use std::arch::asm;
 use std::cell::Cell;
 use std::io::Write;
@@ -11,10 +11,9 @@ unsafe extern "C" fn getpid() -> i32 {
 
     #[cfg(target_arch = "x86_64")]
     {
-        const GETPID: usize = 39;
         asm!(
             "syscall",
-            inlateout("rax") GETPID => result,
+            inlateout("rax") Syscall::GetPid as usize => result,
             out("rcx") _,
             out("r11") _,
             options(nostack),
@@ -33,10 +32,9 @@ unsafe extern "C" fn raise(signal_number: i32) -> i32 {
     let result: isize;
     #[cfg(target_arch = "x86_64")]
     {
-        const TGKILL: usize = 234;
         asm!(
             "syscall",
-            inlateout("rax") TGKILL => result,
+            inlateout("rax") Syscall::TgKill as usize => result,
             in("rdi") process_id,
             in("rsi") thread_id.as_u64().get(),
             in("rdx") signal_number,

--- a/src/libc/threads/mod.rs
+++ b/src/libc/threads/mod.rs
@@ -1,4 +1,4 @@
-use crate::signature_matches_libc;
+use crate::{signature_matches_libc, syscall::Syscall};
 use std::arch::asm;
 
 mod key;
@@ -10,10 +10,9 @@ unsafe extern "C" fn gettid() -> i32 {
 
     #[cfg(target_arch = "x86_64")]
     {
-        const GETPID: usize = 186;
         asm!(
             "syscall",
-            inlateout("rax") GETPID => result,
+            inlateout("rax") Syscall::GetTid as usize => result,
             out("rcx") _,
             out("r11") _,
             options(nostack),

--- a/src/syscall/x86_64/exit.rs
+++ b/src/syscall/x86_64/exit.rs
@@ -1,17 +1,17 @@
 use std::arch::asm;
 
+use super::Syscall;
+
 const CODE_ADDEND: usize = 22200;
 
 pub const EXIT_UNKNOWN_RELOCATION: usize = CODE_ADDEND + 1;
 
 #[inline(always)]
 pub fn exit(code: usize) -> ! {
-    const EXIT: usize = 60;
-
     unsafe {
         asm!(
             "syscall",
-            in("rax") EXIT,
+            in("rax") Syscall::Exit as usize,
             in("rdi") code,
             options(noreturn)
         )

--- a/src/syscall/x86_64/mod.rs
+++ b/src/syscall/x86_64/mod.rs
@@ -1,2 +1,17 @@
+#[repr(usize)]
+pub enum Syscall {
+    Read = 0,
+    Write = 1,
+    Close = 3,
+    Mmap = 9,
+    Munmap = 11,
+    GetPid = 39,
+    Exit = 60,
+    ArchPrctl = 158,
+    GetTid = 186,
+    TgKill = 234,
+    OpenAt = 257,
+}
+
 pub mod exit;
 pub mod thread_pointer;

--- a/src/syscall/x86_64/thread_pointer.rs
+++ b/src/syscall/x86_64/thread_pointer.rs
@@ -1,15 +1,15 @@
 use std::{arch::asm, ffi::c_void};
 
+use super::Syscall;
 use crate::io_macros::syscall_debug_assert;
 
 #[inline(always)]
 pub unsafe fn set_thread_pointer(new_pointer: *mut c_void) {
-    const ARCH_PRCTL: usize = 158;
     const ARCH_SET_FS: usize = 4098;
 
     asm!(
         "syscall",
-        in("rax") ARCH_PRCTL,
+        in("rax") Syscall::ArchPrctl as usize,
         in("rdi") ARCH_SET_FS,
         in("rsi") new_pointer,
         out("rcx") _,


### PR DESCRIPTION
- Add `#[repr(usize)]` `Syscall` enum in `src/syscall/x86_64/mod.rs` with all 11 syscall numbers
- Replace per-function `const` syscall numbers across libc wrappers & internal syscall sites

Closes: #25