### PR TITLE
merge(worktree-dynamic_array_parsing_scalability): extract DynamicFields struct from ObjectData;

### DIFF
--- a/src/libc/environ.rs
+++ b/src/libc/environ.rs
@@ -1,11 +1,7 @@
-use std::{
-    ffi::CStr,
-    mem::MaybeUninit,
-};
+use std::{ffi::CStr, mem::MaybeUninit};
 
 use crate::{
-    io_macros::syscall_debug_assert,
-    signature_matches_libc,
+    io_macros::syscall_debug_assert, signature_matches_libc,
     start::environment_variables::EnvironmentIter,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,11 @@
 mod syscall;
 
 mod elf;
+mod error;
+mod global_allocator;
 mod io_macros;
 mod libc;
 mod objects;
 mod page_size;
-mod error;
-mod global_allocator;
 mod start;
 mod utils;

--- a/src/objects/object_data/dynamic_fields.rs
+++ b/src/objects/object_data/dynamic_fields.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_void, ptr, ptr::null};
+use std::{ffi::c_void, ptr, ptr::null, ptr::NonNull};
 
 use crate::elf::dynamic_array::{DT_GNU_HASH, DT_HASH, DT_NEEDED, DT_PLTGOT, DT_RPATH, DT_RUNPATH};
 #[cfg(debug_assertions)]
@@ -9,8 +9,8 @@ use crate::{
 use crate::{
     elf::{
         dynamic_array::{
-            DynamicArrayItem, DynamicArrayIter, DT_INIT_ARRAY, DT_INIT_ARRAYSZ, DT_RELA,
-            DT_RELASZ, DT_STRTAB, DT_SYMTAB,
+            DynamicArrayItem, DynamicArrayIter, DT_INIT_ARRAY, DT_INIT_ARRAYSZ, DT_RELA, DT_RELASZ,
+            DT_STRTAB, DT_SYMTAB,
         },
         relocate::Rela,
         string_table::StringTable,
@@ -19,9 +19,9 @@ use crate::{
     io_macros::syscall_debug_assert,
 };
 
-use super::hash_tables::HashTable;
-use super::path_resolver::PathResolver;
-use super::{AnyDynamic, Dynamic, InitArrayFunction};
+use super::{
+    hash_tables::HashTable, path_resolver::PathResolver, AnyDynamic, Dynamic, InitArrayFunction,
+};
 
 pub struct DynamicFields<T: AnyDynamic> {
     pub global_offset_table: *const usize,
@@ -81,8 +81,7 @@ impl<T: AnyDynamic> DynamicFields<T> {
                     string_table_pointer = base.byte_add(item.d_un.d_ptr.addr()) as *const u8
                 }
                 DT_SYMTAB => {
-                    symbol_table_pointer =
-                        base.byte_add(item.d_un.d_ptr.addr()) as *const Symbol
+                    symbol_table_pointer = base.byte_add(item.d_un.d_ptr.addr()) as *const Symbol
                 }
                 #[cfg(debug_assertions)]
                 DT_SYMENT => syscall_assert!(item.d_un.d_val == size_of::<Symbol>()),
@@ -124,13 +123,15 @@ impl<T: AnyDynamic> DynamicFields<T> {
         let string_table = StringTable::new(string_table_pointer);
         let symbol_table = SymbolTable::new(symbol_table_pointer);
 
-        syscall_debug_assert!(rela_pointer != null());
         let rela_slice = ptr::slice_from_raw_parts(rela_pointer, rela_count);
 
         let init_array = if init_array_pointer.is_null() || init_array_size == 0 {
             None
         } else {
-            Some(ptr::slice_from_raw_parts(init_array_pointer, init_array_size))
+            Some(ptr::slice_from_raw_parts(
+                init_array_pointer,
+                init_array_size,
+            ))
         };
 
         let path_resolver = runpath_string_table_index

--- a/src/objects/object_data/mod.rs
+++ b/src/objects/object_data/mod.rs
@@ -21,8 +21,7 @@ pub type InitArrayFunction =
 
 pub struct ObjectData<T: AnyDynamic> {
     pub base: *const c_void,
-    pub dynamic_array: *const DynamicArrayItem,
-    pub dynamic: DynamicFields<T>,
+    pub dynamic_fields: DynamicFields<T>,
     pub tls_data: Option<ThreadLocalData>,
 }
 
@@ -59,8 +58,8 @@ impl<T: AnyDynamic> ObjectData<T> {
         for header in &*program_header_table {
             match header.p_type {
                 PT_PHDR => {
-                    base = (*program_header_table).as_ptr().byte_sub(header.p_vaddr)
-                        as *const c_void;
+                    base =
+                        (*program_header_table).as_ptr().byte_sub(header.p_vaddr) as *const c_void;
                 }
                 PT_DYNAMIC => dynamic_program_header = header,
                 PT_TLS => tls_program_header = Some(header.to_owned()),
@@ -83,8 +82,7 @@ impl<T: AnyDynamic> ObjectData<T> {
 
         Self {
             base,
-            dynamic_array,
-            dynamic: DynamicFields::from_dynamic_array(base, dynamic_array),
+            dynamic_fields: DynamicFields::from_dynamic_array(base, dynamic_array),
             tls_data: tls_program_header.map(|tls_program_header| ThreadLocalData {
                 tls_program_header,
                 thread_local_allocation: None,

--- a/src/objects/strategies/init_array.rs
+++ b/src/objects/strategies/init_array.rs
@@ -32,7 +32,7 @@ impl InitArray {
 impl<T: AsObjectDataSlice> Stratagem<T> for InitArray {
     fn run(&self, object_data: &mut T) -> Result<(), MirosError> {
         object_data.as_object_slice_mut().iter().for_each(|object| {
-            if let Some(init_functions) = unsafe { object.dynamic.init_functions() } {
+            if let Some(init_functions) = unsafe { object.dynamic_fields.init_functions() } {
                 init_functions
                     .iter()
                     .filter(|init_fn| **init_fn as *const c_void != null())

--- a/src/objects/strategies/load_dependencies.rs
+++ b/src/objects/strategies/load_dependencies.rs
@@ -54,9 +54,8 @@ unsafe fn load_segment(
 ) {
     debug_assert!(segment_program_header.p_type == PT_LOAD);
 
-    let segment_start = page_size::get_page_start(
-        in_memory_base.byte_add(segment_program_header.p_vaddr) as usize,
-    );
+    let segment_start =
+        page_size::get_page_start(in_memory_base.byte_add(segment_program_header.p_vaddr) as usize);
 
     let file_start = page_size::get_page_start(segment_program_header.p_offset);
     let file_length =
@@ -145,7 +144,7 @@ impl Stratagem<ObjectDataVector> for LoadDependencies {
     fn run(&self, object_data: &mut ObjectDataVector) -> Result<(), crate::error::MirosError> {
         let _object_names = object_data
             .iter()
-            .flat_map(|object| object.dynamic.dependency_names());
+            .flat_map(|object| object.dynamic_fields.dependency_names());
         Ok(())
     }
 }

--- a/src/objects/strategies/relocate.rs
+++ b/src/objects/strategies/relocate.rs
@@ -88,7 +88,7 @@ where
             .as_object_slice_mut()
             .iter()
             .try_for_each(|object| {
-                unsafe { object.dynamic.rela_slice() }
+                unsafe { object.dynamic_fields.rela_slice() }
                     .iter()
                     .try_for_each(|rela| unsafe { self.rela(*rela, object) })
             })

--- a/src/start/mod.rs
+++ b/src/start/mod.rs
@@ -93,8 +93,7 @@ pub unsafe extern "C" fn relocate_and_calculate_jump_address(stack_pointer: *mut
     };
 
     let relocate = Relocate::new();
-    let thread_local_storage =
-        ThreadLocalStorage::new(auxv_info.pseudorandom_bytes);
+    let thread_local_storage = ThreadLocalStorage::new(auxv_info.pseudorandom_bytes);
     let init_array = InitArray::new(arg_count, arg_pointer, env_pointer, auxv_pointer);
 
     let stratagems: &[&dyn Stratagem<ObjectDataSingle>] = &[&thread_local_storage, &init_array];


### PR DESCRIPTION
- Extract `DynamicFields<T>` struct into `dynamic_fields.rs` to own all dynamic-array-derived fields & their parse+assembly pipeline
- Reduce `ObjectData` to 4 fields: `base`, `dynamic_array`, `dynamic`, `tls_data`
- Simplify `build_internal` from 110 lines to 12 by delegating to `DynamicFields::from_dynamic_array`
- Move `rela_slice()`, `init_functions()`, `dependency_names()` accessors to `DynamicFields`
- Update strategy call sites to use `object.dynamic.*`

Closes: #29