### PR TITLE
merge(cxa_thread_atexit_impl): add no-op stub for TLS destructor registration;

### DIFF
--- a/src/libc/threads/mod.rs
+++ b/src/libc/threads/mod.rs
@@ -1,8 +1,18 @@
-use std::arch::asm;
+use std::{arch::asm, ffi::c_void};
 
 use crate::{signature_matches_libc, syscall::Syscall};
 
 mod key;
+
+// TODO: Store and invoke destructors when thread support is implemented.
+#[no_mangle]
+unsafe extern "C" fn __cxa_thread_atexit_impl(
+    _destructor: unsafe extern "C" fn(*mut c_void),
+    _object: *mut c_void,
+    _dso_symbol: *mut c_void,
+) -> i32 {
+    0
+}
 
 #[no_mangle]
 unsafe extern "C" fn gettid() -> i32 {


### PR DESCRIPTION
- Add `__cxa_thread_atexit_impl` no-op stub returning 0 (success) to unblock TLS access in single-threaded context

Closes: #63