### PR TITLE
merge(pread64): implement pread64 libc wrapper;

### DIFF
--- a/src/libc/fs/mod.rs
+++ b/src/libc/fs/mod.rs
@@ -1,5 +1,6 @@
 mod close;
 mod file_status;
 mod open;
+mod pread;
 mod read;
 mod write;

--- a/src/libc/fs/pread.rs
+++ b/src/libc/fs/pread.rs
@@ -1,0 +1,41 @@
+use std::{
+    arch::asm,
+    ffi::c_void,
+    os::fd::{AsRawFd, BorrowedFd},
+};
+
+use crate::{signature_matches_libc, syscall::Syscall};
+
+#[no_mangle]
+unsafe extern "C" fn pread64(
+    file_descriptor: BorrowedFd<'_>,
+    buffer_pointer: *mut c_void,
+    buffer_length_in_bytes: usize,
+    offset: i64,
+) -> isize {
+    signature_matches_libc!(libc::pread64(
+        std::mem::transmute(file_descriptor),
+        buffer_pointer.cast(),
+        buffer_length_in_bytes,
+        offset
+    ));
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        let result: isize;
+        unsafe {
+            asm!(
+                "syscall",
+                inlateout("rax") Syscall::PRead64 as usize => result,
+                in("rdi") file_descriptor.as_raw_fd(),
+                in("rsi") buffer_pointer,
+                in("rdx") buffer_length_in_bytes,
+                in("r10") offset,
+                out("rcx") _,
+                out("r11") _,
+                options(nostack)
+            )
+        };
+        result
+    }
+}

--- a/src/syscall/x86_64/mod.rs
+++ b/src/syscall/x86_64/mod.rs
@@ -1,6 +1,7 @@
 #[repr(usize)]
 pub enum Syscall {
     Read = 0,
+    PRead64 = 17,
     Write = 1,
     Close = 3,
     Stat = 4,


### PR DESCRIPTION
- Add `PRead64 = 17` variant to `Syscall` enum
- Add `pread64` syscall wrapper in `src/libc/fs/pread.rs`

Closes: #62