### PR TITLE
merge(is_visible_and_is_defined): add symbol type decomposition & export predicates;

### DIFF
--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -2,6 +2,7 @@ pub mod dynamic_array;
 pub mod header;
 pub mod program_header;
 pub mod relocate;
+pub mod section;
 pub mod string_table;
 pub mod symbol;
 pub mod thread_local_storage;

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -1,0 +1,16 @@
+use bitbybit::bitenum;
+
+/// Special section header indices for the `st_shndx` field of a symbol.
+/// Normal section indices (1..0xFF00) are not represented here and fall into `Err(raw)`.
+///
+/// The reserved range 0xFF00..0xFFFF (`SHN_LORESERVE`..`SHN_HIRESERVE`) includes
+/// processor-specific indices (0xFF00..0xFF1F) and OS-specific indices (0xFF20..0xFF3F)
+/// that are not modeled here — they will also fall into `Err(raw)`.
+#[bitenum(u16, exhaustive = false)]
+#[derive(PartialEq, Eq)]
+pub enum SectionIndex {
+    Undefined = 0,
+    Absolute = 0xFFF1,
+    Common = 0xFFF2,
+    ExtendedIndex = 0xFFFF,
+}

--- a/src/elf/symbol.rs
+++ b/src/elf/symbol.rs
@@ -1,6 +1,42 @@
 use bitbybit::{bitenum, bitfield};
 
+use super::section::SectionIndex;
+
+// NOTE: The `Common` SymbolType and SectionIndex are only valid in relocatable objects;
+// the static linker resolves these into `.bss` before producing a shared object or executable.
+
+/// Symbol types extracted from the lower nibble of `st_info`.
+#[bitenum(u4, exhaustive = false)]
+#[derive(PartialEq, Eq)]
+pub enum SymbolType {
+    NoType = 0,
+    Object = 1,
+    Function = 2,
+    Section = 3,
+    File = 4,
+    Common = 5,
+    Tls = 6,
+}
+
+/// Symbol binding types extracted from the upper nibble of `st_info`.
+#[bitenum(u4, exhaustive = false)]
+#[derive(PartialEq, Eq)]
+pub enum SymbolBinding {
+    Local = 0,
+    Global = 1,
+    Weak = 2,
+}
+
+#[bitfield(u8)]
+pub struct SymbolInfo {
+    #[bits(0..=3, rw)]
+    symbol_type: Option<SymbolType>,
+    #[bits(4..=7, rw)]
+    binding: Option<SymbolBinding>,
+}
+
 #[bitenum(u2, exhaustive = true)]
+#[derive(PartialEq, Eq)]
 pub enum SymbolVisibility {
     Default = 0b00,
     Internal = 0b01,
@@ -23,13 +59,50 @@ pub struct Symbol {
     pub st_value: usize,
     #[cfg(target_pointer_width = "32")]
     pub st_size: usize,
-    pub st_info: u8,
+    pub st_info: SymbolInfo,
     pub st_other: SymbolOtherField,
     pub st_shndx: u16,
     #[cfg(target_pointer_width = "64")]
     pub st_value: usize,
     #[cfg(target_pointer_width = "64")]
     pub st_size: usize,
+}
+
+impl Symbol {
+    pub fn section_index(&self) -> Result<SectionIndex, u16> {
+        SectionIndex::new_with_raw_value(self.st_shndx)
+    }
+
+    pub fn binding(&self) -> Result<SymbolBinding, u8> {
+        self.st_info.binding()
+    }
+
+    pub fn symbol_type(&self) -> Result<SymbolType, u8> {
+        self.st_info.symbol_type()
+    }
+
+    pub fn is_defined(&self) -> bool {
+        self.st_shndx != 0
+    }
+
+    /// Has a known non-local binding. Symbols with OS / processor-specific bindings are conservatively excluded.
+    pub fn is_public(&self) -> bool {
+        matches!(
+            self.binding(),
+            Ok(SymbolBinding::Global | SymbolBinding::Weak)
+        )
+    }
+
+    pub fn is_visible(&self) -> bool {
+        matches!(
+            self.st_other.symbol_visibility(),
+            SymbolVisibility::Default | SymbolVisibility::Protected
+        )
+    }
+
+    pub fn is_exported(&self) -> bool {
+        self.is_visible() && self.is_defined() && self.is_public()
+    }
 }
 
 pub struct SymbolTable(*const Symbol);


### PR DESCRIPTION
- Decompose `st_info: u8` into `SymbolInfo` bitfield with `SymbolType` & `SymbolBinding` enums
- Extract `SectionIndex` enum into new `elf::section` module
- Add `is_defined`, `is_public`, `is_visible` & `is_exported` predicates on `Symbol`
- Add `PartialEq + Eq` to `SymbolVisibility`

Closes: #71