### PR TITLE
merge(symbol_interception): intercept glibc symbols via miros dynamic resolution;

### DIFF
--- a/src/libc/process/libc_start_main.rs
+++ b/src/libc/process/libc_start_main.rs
@@ -1,0 +1,14 @@
+use std::{arch::asm, ffi::c_void};
+
+#[no_mangle]
+unsafe extern "C" fn __libc_start_main(
+    _main: unsafe extern "C" fn(i32, *const *const u8, *const *const u8) -> i32,
+    _argc: i32,
+    _argv: *const *const u8,
+    _init: *const c_void,
+    _fini: *const c_void,
+    _rtld_fini: *const c_void,
+    _stack_end: *const c_void,
+) -> i32 {
+    asm!("ud2", options(noreturn, nostack));
+}

--- a/src/libc/process/mod.rs
+++ b/src/libc/process/mod.rs
@@ -1,3 +1,5 @@
+mod libc_start_main;
+
 use std::{arch::asm, cell::Cell, io, io::Write, process, thread};
 
 use crate::{signature_matches_libc, syscall::Syscall};

--- a/src/libc/str/mod.rs
+++ b/src/libc/str/mod.rs
@@ -1,3 +1,5 @@
+mod printf;
+
 use crate::signature_matches_libc;
 
 #[no_mangle]

--- a/src/libc/str/printf.rs
+++ b/src/libc/str/printf.rs
@@ -1,0 +1,6 @@
+use std::arch::asm;
+
+#[no_mangle]
+unsafe extern "C" fn printf(_format: *const i8, ...) -> i32 {
+    asm!("ud2", options(noreturn, nostack));
+}

--- a/src/objects/object_data_map.rs
+++ b/src/objects/object_data_map.rs
@@ -10,23 +10,29 @@ use crate::{
 
 pub struct ObjectDataMap {
     pub(crate) program: ObjectData,
+    pub(crate) miros: ObjectData,
     pub(crate) dependencies: IndexMap<String, ObjectData>,
 }
 
 impl ObjectDataMap {
-    pub fn new(program: ObjectData) -> Self {
+    pub fn new(program: ObjectData, miros: ObjectData) -> Self {
         Self {
             program,
+            miros,
             dependencies: IndexMap::new(),
         }
     }
 
     pub fn iter_objects(&self) -> impl Iterator<Item = &ObjectData> {
-        std::iter::once(&self.program).chain(self.dependencies.values())
+        std::iter::once(&self.program)
+            .chain(self.dependencies.values())
+            .chain(std::iter::once(&self.miros))
     }
 
     pub fn iter_objects_mut(&mut self) -> impl Iterator<Item = &mut ObjectData> {
-        std::iter::once(&mut self.program).chain(self.dependencies.values_mut())
+        std::iter::once(&mut self.program)
+            .chain(self.dependencies.values_mut())
+            .chain(std::iter::once(&mut self.miros))
     }
 
     pub fn resolve_symbol_address(

--- a/src/objects/strategies/load_dependencies.rs
+++ b/src/objects/strategies/load_dependencies.rs
@@ -5,6 +5,8 @@ use crate::{
     objects::{object_data::ObjectData, object_data_map::ObjectDataMap, strategies::Stratagem},
 };
 
+const INTERCEPTED_LIBRARIES: &[&str] = &["libc.so.6", "libpthread.so.0", "ld-linux-x86-64.so.2"];
+
 pub struct LoadDependencies {}
 
 impl LoadDependencies {
@@ -23,7 +25,9 @@ impl Stratagem for LoadDependencies {
             .collect();
 
         while let Some((dependency_name, declarer_key)) = pending.pop_front() {
-            if object_data.dependencies.contains_key(&dependency_name) {
+            if object_data.dependencies.contains_key(&dependency_name)
+                || INTERCEPTED_LIBRARIES.contains(&dependency_name.as_str())
+            {
                 continue;
             }
 

--- a/src/start/mod.rs
+++ b/src/start/mod.rs
@@ -109,12 +109,18 @@ pub unsafe extern "C" fn relocate_and_calculate_jump_address(stack_pointer: *mut
 
     println!("{:?}", env::vars());
 
+    let miros_object_data = if auxv_info.base.is_null() {
+        ObjectData::from_program_headers(program_header_table).unwrap()
+    } else {
+        ObjectData::from_base(auxv_info.base).unwrap()
+    };
+
     let executable = if auxv_info.base.is_null() {
         todo!()
     } else {
         ObjectData::from_program_headers(program_header_table).unwrap()
     };
-    let mut executable_and_dependencies = ObjectDataMap::new(executable);
+    let mut executable_and_dependencies = ObjectDataMap::new(executable, miros_object_data);
 
     let load_dependencies = LoadDependencies::new();
     let relocate = Relocate::new();


### PR DESCRIPTION
- Skip loading libc.so.6, libpthread.so.0, and ld-linux-x86-64.so.2 during dependency resolution
- Add miros' own ObjectData to ObjectDataMap as a fallback symbol provider, searched after program + dependencies
- Add ud2 stubs for __libc_start_main and printf to confirm symbol resolution works

Closes: #26